### PR TITLE
escape attributes when generating HTML

### DIFF
--- a/src/html_writer.rs
+++ b/src/html_writer.rs
@@ -26,7 +26,11 @@ impl<'a, M, W: io::Write> DomNodeProcessor<'a, M> for HtmlWriter<W> {
                 DomValue::Element { tag: tagname } => {
                     write!(w, "<{}", tagname)?;
                     for attr in node.attributes() {
-                        write!(w, " {}=\"{}\"", attr.0, attr.1)?;
+                        write!(w, " {}=\"", attr.0)?;
+                        for escaped_u8 in Escape::new(attr.1.as_str().bytes()) {
+                            w.write(&[escaped_u8])?;
+                        }
+                        write!(w, "\"")?;
                     }
                     write!(w, ">")?;
                     node.children().process_all::<HtmlWriter<W>>(w)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -427,6 +427,24 @@ mod tests {
         );
     }
 
+    #[test]
+    fn escapes_text() {
+        fn local_div(text_value: &'static str) -> impl DomNode<Never> + 'static {
+            div ((
+                text_value,
+            ))
+        }
+
+        assert_eq!(
+            r#"<div>embedded &#34;quotes&#34;</div>"#.to_string(),
+            local_div(r#"embedded "quotes""#).displayable().to_string()
+        );
+        assert_eq!(
+            r#"<div>embedded &lt;tag&gt;</div>"#.to_string(),
+            local_div(r#"embedded <tag>"#).displayable().to_string()
+        );
+    }
+
     fn check_attribute_list<M, T: DomNode<M>>(div: T) {
         assert_eq!(div.get_attribute(0), Some(&("attr1", Str("val1"))));
         assert_eq!(div.get_attribute(1), Some(&("attr2", Str("val2"))));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -428,6 +428,25 @@ mod tests {
     }
 
     #[test]
+    fn escapes_attributes() {
+        fn local_div(attr_value: &'static str) -> impl DomNode<Never> + 'static {
+            div ((
+                attributes([("attr", Str(attr_value))]),
+                (),
+            ))
+        }
+
+        assert_eq!(
+            r#"<div attr="embedded &#34;quotes&#34;"></div>"#.to_string(),
+            local_div(r#"embedded "quotes""#).displayable().to_string()
+        );
+        assert_eq!(
+            r#"<div attr="embedded &lt;tag&gt;"></div>"#.to_string(),
+            local_div(r#"embedded <tag>"#).displayable().to_string()
+        );
+    }
+
+    #[test]
     fn escapes_text() {
         fn local_div(text_value: &'static str) -> impl DomNode<Never> + 'static {
             div ((


### PR DESCRIPTION
Attribute values should be escaped when generating HTML.  These values can contain embedded quotes, which would break the generated HTML code or at worst allow for XSS attacks.

Note, the implementation here only escapes included html code. Attributes can also include javascript, and the escaping method here would not guard against malicious javascript injected into attributes. This may fall outside of the responsibilities of this library though.